### PR TITLE
feat: Differentiate health and affection icons

### DIFF
--- a/src/components/YuaCharacter.css
+++ b/src/components/YuaCharacter.css
@@ -20,6 +20,14 @@
 .yua-character-status {
   margin-top: 20px;
   display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 24px; /* Increased gap */
+  width: 100%;
+}
+
+.status-item {
+  display: flex;
   align-items: center;
   gap: 8px;
 }
@@ -43,9 +51,12 @@
   }
 }
 
-.yua-character-health-text {
+.yua-character-health-text,
+.yua-character-affection-text {
   font-family: 'Roboto', sans-serif;
-  font-size: 16px;
+  font-size: 18px;
   font-weight: bold;
   color: #333;
+  min-width: 3ch; /* Reserve space for up to 3 digits */
+  text-align: left;
 }

--- a/src/components/YuaCharacter.jsx
+++ b/src/components/YuaCharacter.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import FavoriteIcon from '@mui/icons-material/Favorite';
+import HealingIcon from '@mui/icons-material/Healing';
 import './YuaCharacter.css';
 
 /**
@@ -26,11 +27,20 @@ const YuaCharacter = ({ health, affection }) => {
         alt="Yua"
       />
       <div className="yua-character-status">
-        <FavoriteIcon
-          className={heartClass}
-          style={{ color: heartColor, fontSize: heartSize }}
-        />
-        <span className="yua-character-health-text">Health: {health}</span>
+        {/* Affection Status */}
+        <div className="status-item affection-status">
+          <FavoriteIcon
+            className={heartClass}
+            style={{ color: heartColor, fontSize: heartSize }}
+          />
+          <span className="yua-character-affection-text">{affection}</span>
+        </div>
+
+        {/* Health Status */}
+        <div className="status-item health-status">
+          <HealingIcon style={{ color: '#4caf50', fontSize: '24px' }} />
+          <span className="yua-character-health-text">{health}</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
To address the confusion between the health and affection status indicators, this change introduces a separate icon for health.

- Replaced the single heart icon with two distinct icons:
  - `FavoriteIcon` (heart) for Affection.
  - `HealingIcon` (medical cross) for Health.
- Updated the `YuaCharacter` component to display both icons with their corresponding numerical values.
- Adjusted the CSS to ensure both status indicators are clearly displayed and aligned.