### PR TITLE
Feat: Add asset progress bar to game screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -250,6 +250,7 @@ function App() {
           yuaHealth={gameState.yuaHealth}
           yuaAffection={gameState.yuaAffection}
           activeActionTab={activeActionTab}
+          initialMoney={INITIAL_GAME_STATE.money}
         />
       </main>
       <Footer

--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -172,6 +172,7 @@ function GameScreen({
   yuaHealth,
   yuaAffection,
   activeActionTab,
+  initialMoney,
 }) {
   const formatMoney = (amount) => {
     return new Intl.NumberFormat('ja-JP', {
@@ -181,6 +182,13 @@ function GameScreen({
   };
 
   const isActionDisabled = gameState.gameStatus !== 'ongoing';
+
+  const moneyPercent = (gameState.money / initialMoney) * 100;
+  const getMoneyBarColor = (percent) => {
+    if (percent > 50) return 'success';
+    if (percent > 20) return 'warning';
+    return 'error';
+  };
 
   return (
     <Box className="game-screen" sx={{ p: 3 }}>
@@ -205,6 +213,13 @@ function GameScreen({
                   icon={<MonetizationOn color="success" />}
                   title="資産"
                   value={formatMoney(gameState.money)}
+                  footer={
+                    <LinearProgress
+                      variant="determinate"
+                      value={moneyPercent}
+                      color={getMoneyBarColor(moneyPercent)}
+                    />
+                  }
                 />
               </Grid>
               <Grid item xs={6}>


### PR DESCRIPTION
This commit introduces a visual progress bar for the player's assets on the game screen.

- The `GameScreen` component now displays a `LinearProgress` bar under the asset value.
- The progress bar's value is calculated as a percentage of the initial assets.
- The color of the progress bar dynamically changes to reflect the asset level:
  - Green: > 50%
  - Yellow: > 20%
  - Red: <= 20%
- `App.jsx` is updated to pass the initial asset value to the `GameScreen` component.

This addresses the user's request for a more visual representation of the remaining assets.